### PR TITLE
ci: Update verify_build.yml

### DIFF
--- a/.github/workflows/verify_build.yml
+++ b/.github/workflows/verify_build.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           file: jacoco.xml
           name: codecov
-          token: ${{ secrets.CODECOV_TOKEN }}
+          tags: coverage
         
   test_java_8:
     name: Assert tests and javadoc with java 8


### PR DESCRIPTION
Try to fix that PRs from forks and externals appear in codecov.

Codecov tokens are not required for public repositories